### PR TITLE
fix run_winecommand typo in Actions.md

### DIFF
--- a/dependencies/structure/Actions.md
+++ b/dependencies/structure/Actions.md
@@ -324,7 +324,7 @@ This action is used to register a DLL and ActiveX control in the bottle.
 ```
 
 
-## `set_registry_key`
+## `set_register_key`
 This action is used to set a key in the bottle's registry (WINE Registry).
 
 ### Parameters

--- a/installers/structure/Actions.md
+++ b/installers/structure/Actions.md
@@ -146,7 +146,7 @@ per each command:
 
 ### Example
 ```yaml
-- action: wine_winecommand
+- action: run_winecommand
   commands:
     - command: start steam://install/39140
       arguments: /S


### PR DESCRIPTION
Came to the same issue that was already mentioned in https://github.com/bottlesdevs/maintainers-docs/issues/6

This correspond to [code](https://github.com/bottlesdevs/Bottles/blob/158fac515cfd34c3ea0768a9800a9b8facbd665a/bottles/backend/managers/installer.py#L169C37-L169C52) and was tested locally with custom installer